### PR TITLE
Add model card hash checks with force option

### DIFF
--- a/launch/dynamo-run/src/flags.rs
+++ b/launch/dynamo-run/src/flags.rs
@@ -131,6 +131,10 @@ pub struct Flags {
     #[arg(long)]
     pub kv_cache_block_size: Option<usize>,
 
+    /// Overwrite an existing ModelDeploymentCard in the key-value store
+    #[arg(long)]
+    pub force: bool,
+
     /// Additional engine-specific arguments from a JSON file.
     /// Contains a mapping of parameter names to values.
     #[arg(long)]
@@ -211,6 +215,9 @@ impl Flags {
         if let Some(weight) = self.kv_waiting_requests_weight {
             out.push("--kv-waiting-requests-weight".to_string());
             out.push(weight.to_string());
+        }
+        if self.force {
+            out.push("--force".to_string());
         }
         out.extend(self.last.clone());
         out

--- a/launch/dynamo-run/src/input/endpoint.rs
+++ b/launch/dynamo-run/src/input/endpoint.rs
@@ -39,6 +39,7 @@ pub async fn run(
     distributed_runtime: DistributedRuntime,
     path: String,
     engine_config: EngineConfig,
+    force: bool,
 ) -> anyhow::Result<()> {
     let cancel_token = distributed_runtime.primary_token().clone();
     let endpoint_id: EndpointId = path.parse()?;
@@ -61,7 +62,7 @@ pub async fn run(
                 Pin<Box<dyn AsyncEngineStream<Annotated<NvCreateChatCompletionStreamResponse>>>>,
             >::for_engine(engine)?;
 
-            model.attach(&endpoint, ModelType::Chat).await?;
+            model.attach(&endpoint, ModelType::Chat, force).await?;
             let fut_chat = endpoint.endpoint_builder().handler(ingress_chat).start();
 
             (Box::pin(fut_chat), Some(model.card().clone()))
@@ -86,7 +87,7 @@ pub async fn run(
                 .link(frontend)?;
             let ingress = Ingress::for_pipeline(pipeline)?;
 
-            model.attach(&endpoint, ModelType::Backend).await?;
+            model.attach(&endpoint, ModelType::Backend, force).await?;
             let fut = endpoint.endpoint_builder().handler(ingress).start();
 
             (Box::pin(fut), Some(model.card().clone()))

--- a/launch/dynamo-run/src/lib.rs
+++ b/launch/dynamo-run/src/lib.rs
@@ -312,7 +312,7 @@ pub async fn run(
         }
         Input::Endpoint(path) => {
             let distributed_runtime = DistributedRuntime::from_settings(runtime.clone()).await?;
-            crate::input::endpoint::run(distributed_runtime, path, engine_config).await?;
+            crate::input::endpoint::run(distributed_runtime, path, engine_config, flags.force).await?;
         }
     }
 

--- a/launch/llmctl/src/main.rs
+++ b/launch/llmctl/src/main.rs
@@ -228,7 +228,7 @@ async fn add_model(
     let endpoint = endpoint_from_name(distributed, &namespace, endpoint_name)?;
 
     let mut model = LocalModel::with_name_only(&model_name);
-    model.attach(&endpoint, model_type).await?;
+    model.attach(&endpoint, model_type, false).await?;
 
     Ok(())
 }

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -94,7 +94,7 @@ fn log_message(level: &str, message: &str, module: &str, file: &str, line: u32) 
 }
 
 #[pyfunction]
-#[pyo3(signature = (model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None))]
+#[pyo3(signature = (model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, force=false))]
 fn register_llm<'p>(
     py: Python<'p>,
     model_type: ModelType,
@@ -103,6 +103,7 @@ fn register_llm<'p>(
     model_name: Option<&str>,
     context_length: Option<usize>,
     kv_cache_block_size: Option<usize>,
+    force: bool,
 ) -> PyResult<Bound<'p, PyAny>> {
     let model_type_obj = match model_type {
         ModelType::Chat => llm_rs::model_type::ModelType::Chat,
@@ -128,7 +129,7 @@ fn register_llm<'p>(
 
         // Advertise ourself on etcd so ingress can find us
         local_model
-            .attach(&endpoint.inner, model_type_obj)
+            .attach(&endpoint.inner, model_type_obj, force)
             .await
             .map_err(to_pyerr)?;
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -641,7 +641,7 @@ class ModelType:
     """What type of request this model needs: Chat, Component or Backend (pre-processed)"""
     ...
 
-async def register_llm(model_type: ModelType, endpoint: Endpoint, model_path: str, model_name: Optional[str] = None, context_length: Optional[int] = None, kv_cache_block_size: Optional[int] = None) -> None:
+async def register_llm(model_type: ModelType, endpoint: Endpoint, model_path: str, model_name: Optional[str] = None, context_length: Optional[int] = None, kv_cache_block_size: Optional[int] = None, force: bool = False) -> None:
     """Attach the model at path to the given endpoint, and advertise it as model_type"""
     ...
 

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -128,6 +128,7 @@ impl LocalModel {
         // --model-config takes precedence over --model-path
         let model_config_path = override_config.unwrap_or(&full_path);
         let mut card = ModelDeploymentCard::load(&model_config_path).await?;
+        card.compute_file_hashes()?;
         card.set_name(&model_name);
 
         Ok(LocalModel { full_path, card })
@@ -139,6 +140,7 @@ impl LocalModel {
         &mut self,
         endpoint: &Endpoint,
         model_type: ModelType,
+        force: bool,
     ) -> anyhow::Result<()> {
         // A static component doesn't have an etcd_client because it doesn't need to register
         let Some(etcd_client) = endpoint.drt().etcd_client() else {
@@ -147,14 +149,30 @@ impl LocalModel {
         self.ensure_unique(endpoint.component(), self.display_name())
             .await?;
 
+        // Publish the Model Deployment Card if not already present
+        let kvstore: Box<dyn KeyValueStore> = Box::new(EtcdStorage::new(etcd_client.clone()));
+        let card_store = Arc::new(KeyValueStoreManager::new(kvstore));
+        let key_slug = self.card.slug();
+        if let Some(existing) = card_store
+            .load::<ModelDeploymentCard>(model_card::ROOT_PATH, &key_slug)
+            .await?
+        {
+            if existing.file_hashes != self.card.file_hashes && !force {
+                anyhow::bail!(
+                    "ModelDeploymentCard already exists with different content. Use --force to overwrite or delete the key."
+                );
+            }
+            if !force {
+                tracing::debug!(model=%key_slug, "Model card already published" );
+                return Ok(());
+            }
+        }
+
         // Store model config files in NATS object store
         let nats_client = endpoint.drt().nats_client();
         self.card.move_to_nats(nats_client.clone()).await?;
 
-        // Publish the Model Deployment Card to etcd
-        let kvstore: Box<dyn KeyValueStore> = Box::new(EtcdStorage::new(etcd_client.clone()));
-        let card_store = Arc::new(KeyValueStoreManager::new(kvstore));
-        let key = self.card.slug().to_string();
+        let key = key_slug.to_string();
         card_store
             .publish(model_card::ROOT_PATH, None, &key, &mut self.card)
             .await?;

--- a/lib/llm/src/model_card/model.rs
+++ b/lib/llm/src/model_card/model.rs
@@ -26,6 +26,7 @@
 //! - Various metadata like revision, publish time, etc.
 
 use std::fmt;
+use std::collections::HashMap;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -130,6 +131,10 @@ pub struct ModelDeploymentCard {
     /// Size of a KV cache block - vllm only currently
     /// Passed to the engine and the KV router.
     pub kv_cache_block_size: usize,
+
+    /// Blake3 hashes of the files backing this card
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub file_hashes: HashMap<String, String>,
 }
 
 impl ModelDeploymentCard {
@@ -197,6 +202,44 @@ impl ModelDeploymentCard {
     pub fn mdcsum(&self) -> String {
         let json = self.to_json().unwrap();
         format!("{}", blake3::hash(json.as_bytes()))
+    }
+
+    /// Calculate blake3 hashes of the files referenced by this card
+    pub fn compute_file_hashes(&mut self) -> anyhow::Result<()> {
+        self.file_hashes.clear();
+        if let Some(ModelInfoType::HfConfigJson(ref path)) = self.model_info {
+            self.file_hashes
+                .insert("config.json".to_string(), blake3_file(Path::new(path))?);
+        }
+        if let Some(ModelInfoType::GGUF(ref path)) = self.model_info {
+            let name = path
+                .file_name()
+                .and_then(|p| p.to_str())
+                .unwrap_or("model.gguf")
+                .to_string();
+            self.file_hashes.insert(name, blake3_file(path)?);
+        }
+        if let Some(TokenizerKind::HfTokenizerJson(ref path)) = self.tokenizer {
+            self.file_hashes
+                .insert("tokenizer.json".to_string(), blake3_file(Path::new(path))?);
+        }
+        if let Some(PromptFormatterArtifact::HfTokenizerConfigJson(ref path)) =
+            self.prompt_formatter
+        {
+            self.file_hashes.insert(
+                "tokenizer_config.json".to_string(),
+                blake3_file(Path::new(path))?,
+            );
+        }
+        if let Some(PromptFormatterArtifact::GGUF(ref path)) = self.prompt_formatter {
+            let name = path
+                .file_name()
+                .and_then(|p| p.to_str())
+                .unwrap_or("prompt.gguf")
+                .to_string();
+            self.file_hashes.insert(name, blake3_file(path)?);
+        }
+        Ok(())
     }
 
     /// Was this card last published a long time ago, suggesting the worker is gone?
@@ -546,4 +589,9 @@ mod tests {
         assert_eq!(config.bos_token_id(), 200000);
         Ok(())
     }
+}
+
+fn blake3_file(path: &Path) -> anyhow::Result<String> {
+    let bytes = std::fs::read(path)?;
+    Ok(blake3::hash(&bytes).to_string())
 }


### PR DESCRIPTION
## Summary
- hash model files in `ModelDeploymentCard`
- compute file hashes on model load
- ensure worker won't overwrite existing model card unless `--force`
- allow forcing with `--force` flag for `dynamo-run`
- propagate `force` through Python bindings and CLI

## Testing
- `cargo check` *(fails: unsuccessful tunnel)*
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68406c82d3448333b55a336e593e1ddc