### PR TITLE
Add group python bindings

### DIFF
--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -196,6 +196,25 @@ class Namespace:
 
     ...
 
+    def group(self, name: str) -> Group:
+        """
+        Create a `Group` object
+        """
+        ...
+
+    def component(self, name: str) -> Component:
+        """
+        Create a `Component` object
+        """
+        ...
+
+class Group:
+    """
+    A group is a collection of components within a namespace
+    """
+
+    ...
+
     def component(self, name: str) -> Component:
         """
         Create a `Component` object

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ValidationError
 from dynamo._core import Backend as Backend
 from dynamo._core import Client as Client
 from dynamo._core import Component as Component
+from dynamo._core import Group as Group
 from dynamo._core import DistributedRuntime as DistributedRuntime
 from dynamo._core import EtcdKvCache as EtcdKvCache
 from dynamo._core import ModelDeploymentCard as ModelDeploymentCard


### PR DESCRIPTION
## Summary
- create a `Group` pyclass in the Rust bindings
- expose `Namespace.group()` and `Group.component()`
- register the new class with the module
- update typing stubs and runtime re‑exports

## Testing
- `cargo fmt --all` *(fails: unsuccessful tunnel)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68471f782fdc83338f70acdda0843960